### PR TITLE
Enable source maps

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -224,6 +224,7 @@ gulp.task('build-app-js', () => {
       output: {
         filename: jsRootFile,
       },
+      devtool: 'source-map',
       module: webpackModuleConf,
     }, webpack2))
     .pipe(gulp.dest(targetDirs.scripts))
@@ -239,6 +240,7 @@ gulp.task('build-sw-js', () => {
       output: {
         filename: swRootFile,
       },
+      devtool: 'source-map',
       module: webpackModuleConf,
     }, webpack2))
     .pipe(gulp.dest(targetDirs.scripts))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,6 +31,7 @@ const atImport = require('postcss-import');
 const sprites = require('postcss-sprites');
 const colorHexAlpha = require('postcss-color-hex-alpha');
 const discardComments = require('postcss-discard-comments');
+const sourcemaps = require('gulp-sourcemaps');
 const rename = require('gulp-rename');
 const stylelint = require('gulp-stylelint');
 const autoprefixer = require('autoprefixer');
@@ -175,6 +176,7 @@ gulp.task('clean', () => {
 
 gulp.task('build-css', () => {
   return gulp.src(sourcePaths.cssEntry)
+    .pipe(sourcemaps.init())
     .pipe(postcss([
       atImport(),
       sprites({
@@ -188,6 +190,7 @@ gulp.task('build-css', () => {
       autoprefixer(),
       discardComments(),
     ]))
+    .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest(targetDirs.styles))
     .pipe(rename(p => {
       p.dirname = path.join(targetDirs.styles, p.dirname);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.6.1",
     "gulp-sequence": "^0.4.6",
+    "gulp-sourcemaps": "^2.6.4",
     "gulp-stylelint": "^5.0.0",
     "gulp-webpack": "^1.5.0",
     "postcss-color-hex-alpha": "^3.0.0",


### PR DESCRIPTION
Before this change the browser developer tools such as the Chrome inspector will show line numbers for transpiled JavaScript and CSS. This pull request enables source map generation. The browser developer tools use these source maps to show the original source file names and line numbers which is helpful since developers know where to look when things go wrong.