### PR TITLE
Add missing license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "dwst",
+  "license": "CC0-1.0",
   "browserslist": [
     "last 1 chrome versions",
     "last 1 firefox versions",


### PR DESCRIPTION
Did not think that the license field in package.json would make much of a difference since the package has never been published to an npm package repository. However, yarn keeps complaining about the missing field, so I thought we might as well add it to get rid of the useless warnings.