### PR TITLE
Bump simple-git to 3.36.0

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -34,7 +34,7 @@ import gulpStylelint from 'gulp-stylelint';
 import autoprefixer from 'autoprefixer';
 import replace from 'gulp-replace';
 import gulpMocha from 'gulp-mocha';
-import {simpleGit} from 'simple-git';
+import {simpleGit} from 'simple-git'; // eslint-disable-line import/namespace
 import {create as bsCreate} from 'browser-sync';
 
 const browserSync = bsCreate();

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "postcss-import": "^12.0.1",
     "postcss-sprites": "^4.2.1",
     "rewire": "^4.0.1",
-    "simple-git": "^3.27.0",
+    "simple-git": "^3.36.0",
     "stylelint": "^9.9.0",
     "stylelint-no-unsupported-browser-features": "^3.0.2",
     "webpack": "^4.28.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1247,6 +1247,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@simple-git/args-pathspec@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@simple-git/args-pathspec@npm:1.0.3"
+  checksum: 10c0/91bfc99daa956df28e4efd683cd799f60c6d169fce6adf71a9efa80a6b5938fed4b03e55fa929cfd51aed64f3ada5c1e4edad45a3872dbd94d11924b3258b5bc
+  languageName: node
+  linkType: hard
+
+"@simple-git/argv-parser@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "@simple-git/argv-parser@npm:1.1.1"
+  dependencies:
+    "@simple-git/args-pathspec": "npm:^1.0.3"
+  checksum: 10c0/2c21166f1bb7c4373e7b4e52bd0c7f333e58ea0ff5ac0b6c2d305835f4a2bcad1ef4bcce3cff63312ac55655ea7be3aba4c7c0c41e3ebcb8bee343f65bb92f5e
+  languageName: node
+  linkType: hard
+
 "@socket.io/component-emitter@npm:~3.1.0":
   version: 3.1.2
   resolution: "@socket.io/component-emitter@npm:3.1.2"
@@ -4223,7 +4239,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.0.0, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.5":
+"debug@npm:^4.0.0, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
   dependencies:
@@ -4232,6 +4248,18 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10c0/db94f1a182bf886f57b4755f85b3a74c39b5114b9377b7ab375dc2cfa3454f09490cc6c30f829df3fc8042bc8b8995f6567ce5cd96f3bc3688bd24027197d9de
+  languageName: node
+  linkType: hard
+
+"debug@npm:^4.4.0":
+  version: 4.4.3
+  resolution: "debug@npm:4.4.3"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/d79136ec6c83ecbefd0f6a5593da6a9c91ec4d7ddc4b54c883d6e71ec9accb5f67a1a5e96d00a328196b5b5c86d365e98d8a3a70856aaf16b4e7b1985e67f5a6
   languageName: node
   linkType: hard
 
@@ -4627,7 +4655,7 @@ __metadata:
     postcss-import: "npm:^12.0.1"
     postcss-sprites: "npm:^4.2.1"
     rewire: "npm:^4.0.1"
-    simple-git: "npm:^3.27.0"
+    simple-git: "npm:^3.36.0"
     stylelint: "npm:^9.9.0"
     stylelint-no-unsupported-browser-features: "npm:^3.0.2"
     webpack: "npm:^4.28.2"
@@ -12171,14 +12199,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-git@npm:^3.27.0":
-  version: 3.27.0
-  resolution: "simple-git@npm:3.27.0"
+"simple-git@npm:^3.36.0":
+  version: 3.36.0
+  resolution: "simple-git@npm:3.36.0"
   dependencies:
     "@kwsites/file-exists": "npm:^1.1.1"
     "@kwsites/promise-deferred": "npm:^1.1.1"
-    debug: "npm:^4.3.5"
-  checksum: 10c0/ef56cabea585377d3e0ca30e4e93447f465d91f23eaf751693cc31f366b5f7636facf52ad5bcd598bfdf295fa60732e7a394303d378995b52e2d221d92e5f9f4
+    "@simple-git/args-pathspec": "npm:^1.0.3"
+    "@simple-git/argv-parser": "npm:^1.1.0"
+    debug: "npm:^4.4.0"
+  checksum: 10c0/4c22e57107535168f354e5abbbf6e618a7b39d76491ca225c70588520fbe86891f3b9a5c4f8a3fc0137e669aad2f0e11f6c6e677bfec07169cd18f29bf23cb77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps the only direct devDep flagged by Dependabot: `simple-git` `^3.27.0` → `^3.36.0`.
- Clears **3 alerts**: 1 critical (CVE-2026-28292, `blockUnsafeOperationsPlugin` bypass via case-insensitive `protocol.allow` enabling RCE), 2 high (CVE-2026-28291, command execution via option-parsing bypass; CVE-2026-6951, remote code execution).
- `gulpfile.babel.js` passes a hardcoded repo URL (`https://github.com/dwst/dwst.github.io.git`) to `simple-git`'s `clone`, so the bypass CVEs weren't reachable in practice. Bumping anyway because the patch is free.

## One ugly bit
A single-line `// eslint-disable-line import/namespace` was needed on the `import {simpleGit} from 'simple-git'` line. `eslint-plugin-import@2.14.0` (pinned in 2018) can't statically parse `simple-git@3.36`'s source — it hits a syntax token it doesn't recognize at line 1213 and bails. The runtime code is fine; this is purely lint-tooling staleness. A proper fix would be bumping `eslint-plugin-import` (and likely `eslint` itself, plus several gulp-eslint plumbing pieces) — out of scope here.

## Test plan
- [x] `yarn install --immutable` clean
- [x] `yarn lint` passes (all four sub-lints)
- [x] `yarn build` produces `dwst.js` 63.7 KiB
- [x] `yarn test` — 109 passing
- [ ] CI lint/test/build jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)