### PR TITLE
Update caniuse-lite to 1.0.30001793

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3323,14 +3323,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001179, caniuse-lite@npm:^1.0.30001688":
-  version: 1.0.30001715
-  resolution: "caniuse-lite@npm:1.0.30001715"
-  checksum: 10c0/0109a7da797ffbe1aa197baa5242b205011098eecec1087ef3d0c58ceea19be325ab6679b2751a78660adc3051a9f77e99d5789938fd1eb1235e6fdf6a1dbf8e
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001782":
+"caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001179, caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001782":
   version: 1.0.30001793
   resolution: "caniuse-lite@npm:1.0.30001793"
   checksum: 10c0/bee8f8b55d1ccdb2076b7355c06fd01916952eadd76b828e4d5fb9ac62d17ec7db0e2b7c326b923478b93526ad1ff74f189cf40c06de0e4a5edbc677009b97fe


### PR DESCRIPTION
## Summary
- Routine browserslist database refresh via `yarn dlx update-browserslist-db@latest`.
- Updates the `caniuse-lite` resolution from `1.0.30001715` (~13 months old) to `1.0.30001793`.
- One-line lockfile diff (the two version entries collapsed into one as part of the cleanup).

## Why
`caniuse-lite` feeds browser-feature data into `autoprefixer`, `@babel/preset-env`, and `stylelint-no-unsupported-browser-features`. When it gets stale, those tools may emit unnecessary vendor prefixes or polyfills, or fail to recognize newer baseline features.

Browserslist nags about staleness above 6 months and we were at ~13 months — visible in `gulp build` output as a recurring `Browserslist: browsers data (caniuse-lite) is 13 months old` warning. This silences it.

## What does NOT change
- Browserslist target (`last 1 chrome/firefox/safari/edge versions`) — same string in `package.json`.
- Build output is functionally identical for those targets. Could in principle drop a vendor prefix or two if a CSS property graduated to unprefixed status in the newer browsers; in practice for this project there's no observable difference.

## Test plan
- [x] `yarn install --immutable` clean
- [x] `yarn lint` passes
- [x] `yarn build` produces expected output, no more browserslist warning
- [x] `yarn test` — 109 passing
- [ ] CI lint/test/build jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)