### PR TITLE
Run mocha via CLI instead of gulp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ yarn build            # gulp build → ./build/<version>/
 yarn build:release    # gulp buildRelease → clones dwst.github.io and merges into ./release/
 yarn lint             # runs lint:js, lint:css, lint:html, lint:knip, lint:format
 yarn lint:js          # eslint CLI (flat config, owns its own file globs)
-yarn test             # gulp mocha (uses @babel/register)
+yarn test             # mocha via @babel/register, runs test/test.js
 gulp dev              # build + browser-sync at ./build with live reload on file change
 ```
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -27,7 +27,6 @@ import sourcemaps from 'gulp-sourcemaps';
 import rename from 'gulp-rename';
 import autoprefixer from 'autoprefixer';
 import replace from 'gulp-replace';
-import gulpMocha from 'gulp-mocha';
 import { simpleGit } from 'simple-git';
 import { create as bsCreate } from 'browser-sync';
 
@@ -109,14 +108,6 @@ const releaseBase = 'release';
 
 // The ending slash seems to be meaninful for some reason
 const appBase = `/${VERSION}/`;
-
-export function mocha() {
-  return gulp.src('test/test.js', { read: false }).pipe(
-    gulpMocha({
-      require: '@babel/register',
-    }),
-  );
-}
 
 export function deleteBuild() {
   return gulp

--- a/knip.json
+++ b/knip.json
@@ -3,11 +3,10 @@
   "entry": [
     "dwst/scripts/dwst.js",
     "dwst/scripts/service_worker.js",
-    "test/test.js",
     "gulpfile.babel.js"
   ],
   "project": ["dwst/scripts/**/*.js", "test/**/*.js", "dwst/test/**/*.js"],
-  "ignoreDependencies": ["@babel/register", "babel-loader"],
+  "ignoreDependencies": ["babel-loader"],
   "rules": {
     "duplicates": "off"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:html": "htmlhint --config .htmlhintrc dwst/dwst.html",
     "lint:js": "eslint .",
     "lint:knip": "knip",
-    "test": "yarn gulp mocha"
+    "test": "mocha --require @babel/register test/test.js"
   },
   "engines": {
     "node": "*"
@@ -40,13 +40,13 @@
     "globals": "^17.6.0",
     "gulp": "^4.0.0",
     "gulp-clean": "^0.4.0",
-    "gulp-mocha": "^9.0.0",
     "gulp-postcss": "^8.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^1.0.0",
     "gulp-sourcemaps": "^2.6.4",
     "htmlhint": "^1.9.2",
     "knip": "^6.14.1",
+    "mocha": "^10.8.2",
     "postcss-color-hex-alpha": "^5.0.2",
     "postcss-discard-comments": "^4.0.1",
     "postcss-import": "^12.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3961,7 +3961,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
+"cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -4027,13 +4027,6 @@ __metadata:
     es5-ext: "npm:^0.10.64"
     type: "npm:^2.7.2"
   checksum: 10c0/3e6ede10cd3b77586c47da48423b62bed161bf1a48bdbcc94d87263522e22f5dfb0e678a6dba5323fdc14c5d8612b7f7eb9e7d9e37b2e2d67a7bf9f116dabe5a
-  languageName: node
-  linkType: hard
-
-"dargs@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "dargs@npm:7.0.0"
-  checksum: 10c0/ec7f6a8315a8fa2f8b12d39207615bdf62b4d01f631b96fbe536c8ad5469ab9ed710d55811e564d0d5c1d548fc8cb6cc70bf0939f2415790159f5a75e0f96c92
   languageName: node
   linkType: hard
 
@@ -4372,13 +4365,13 @@ __metadata:
     globals: "npm:^17.6.0"
     gulp: "npm:^4.0.0"
     gulp-clean: "npm:^0.4.0"
-    gulp-mocha: "npm:^9.0.0"
     gulp-postcss: "npm:^8.0.0"
     gulp-rename: "npm:^1.2.2"
     gulp-replace: "npm:^1.0.0"
     gulp-sourcemaps: "npm:^2.6.4"
     htmlhint: "npm:^1.9.2"
     knip: "npm:^6.14.1"
+    mocha: "npm:^10.8.2"
     postcss-color-hex-alpha: "npm:^5.0.2"
     postcss-discard-comments: "npm:^4.0.1"
     postcss-import: "npm:^12.0.1"
@@ -5141,23 +5134,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^5.0.0":
-  version: 5.1.1
-  resolution: "execa@npm:5.1.1"
-  dependencies:
-    cross-spawn: "npm:^7.0.3"
-    get-stream: "npm:^6.0.0"
-    human-signals: "npm:^2.1.0"
-    is-stream: "npm:^2.0.0"
-    merge-stream: "npm:^2.0.0"
-    npm-run-path: "npm:^4.0.1"
-    onetime: "npm:^5.1.2"
-    signal-exit: "npm:^3.0.3"
-    strip-final-newline: "npm:^2.0.0"
-  checksum: 10c0/c8e615235e8de4c5addf2fa4c3da3e3aa59ce975a3e83533b4f6a71750fb816a2e79610dc5f1799b6e28976c9ae86747a36a606655bf8cb414a74d8d507b304f
-  languageName: node
-  linkType: hard
-
 "expand-brackets@npm:^2.1.4":
   version: 2.1.4
   resolution: "expand-brackets@npm:2.1.4"
@@ -5833,13 +5809,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "get-stream@npm:6.0.1"
-  checksum: 10c0/49825d57d3fd6964228e6200a58169464b8e8970489b3acdc24906c782fb7f01f9f56f8e6653c4a50713771d6658f7cfe051e5eb8c12e334138c9c918b296341
-  languageName: node
-  linkType: hard
-
 "get-symbol-description@npm:^1.1.0":
   version: 1.1.0
   resolution: "get-symbol-description@npm:1.1.0"
@@ -6130,25 +6099,6 @@ __metadata:
   bin:
     gulp: bin/gulp.js
   checksum: 10c0/77adb21dd60ac8ef53624413613c92a010e132bdee8f45f356e0174db72b5a164256de3da5f17f138f57fedc50482b4e433a6839e2af5e79e2f72be11eda3d14
-  languageName: node
-  linkType: hard
-
-"gulp-mocha@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "gulp-mocha@npm:9.0.0"
-  dependencies:
-    dargs: "npm:^7.0.0"
-    execa: "npm:^5.0.0"
-    mocha: "npm:^10.2.0"
-    plugin-error: "npm:^1.0.1"
-    supports-color: "npm:^8.1.1"
-    through2: "npm:^4.0.2"
-  peerDependencies:
-    gulp: ">=4"
-  peerDependenciesMeta:
-    gulp:
-      optional: true
-  checksum: 10c0/1fc09db03d29f1f1de7d33a7d6c17b9dca54cb0746d6e49fb75714565db01dba03c6e86bf981a0b6d261509c864ea69083220020c20275864b410edf73bb7f80
   languageName: node
   linkType: hard
 
@@ -6475,13 +6425,6 @@ __metadata:
     follow-redirects: "npm:^1.0.0"
     requires-port: "npm:^1.0.0"
   checksum: 10c0/148dfa700a03fb421e383aaaf88ac1d94521dfc34072f6c59770528c65250983c2e4ec996f2f03aa9f3fe46cd1270a593126068319311e3e8d9e610a37533e94
-  languageName: node
-  linkType: hard
-
-"human-signals@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "human-signals@npm:2.1.0"
-  checksum: 10c0/695edb3edfcfe9c8b52a76926cd31b36978782062c0ed9b1192b36bebc75c4c87c82e178dfcb0ed0fc27ca59d434198aac0bd0be18f5781ded775604db22304a
   languageName: node
   linkType: hard
 
@@ -7054,13 +6997,6 @@ __metadata:
   dependencies:
     call-bound: "npm:^1.0.3"
   checksum: 10c0/65158c2feb41ff1edd6bbd6fd8403a69861cf273ff36077982b5d4d68e1d59278c71691216a4a64632bd76d4792d4d1d2553901b6666d84ade13bba5ea7bc7db
-  languageName: node
-  linkType: hard
-
-"is-stream@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "is-stream@npm:2.0.1"
-  checksum: 10c0/7c284241313fc6efc329b8d7f08e16c0efeb6baab1b4cd0ba579eb78e5af1aa5da11e68559896a2067cd6c526bd29241dda4eb1225e627d5aa1a89a76d4635a5
   languageName: node
   linkType: hard
 
@@ -7897,13 +7833,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mimic-fn@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "mimic-fn@npm:2.1.0"
-  checksum: 10c0/b26f5479d7ec6cc2bce275a08f146cf78f5e7b661b18114e2506dd91ec7ec47e7a25bf4360e5438094db0560bcc868079fb3b1fb3892b833c1ecbf63f80c95a4
-  languageName: node
-  linkType: hard
-
 "minimatch@npm:^10.2.2":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
@@ -7991,7 +7920,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mocha@npm:^10.2.0":
+"mocha@npm:^10.8.2":
   version: 10.8.2
   resolution: "mocha@npm:10.8.2"
   dependencies:
@@ -8227,15 +8156,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-run-path@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "npm-run-path@npm:4.0.1"
-  dependencies:
-    path-key: "npm:^3.0.0"
-  checksum: 10c0/6f9353a95288f8455cf64cbeb707b28826a7f29690244c1e4bb61ec573256e021b6ad6651b394eb1ccfd00d6ec50147253aba2c5fe58a57ceb111fad62c519ac
-  languageName: node
-  linkType: hard
-
 "num2fraction@npm:^1.2.2":
   version: 1.2.2
   resolution: "num2fraction@npm:1.2.2"
@@ -8414,15 +8334,6 @@ __metadata:
   dependencies:
     mimic-fn: "npm:^1.0.0"
   checksum: 10c0/b4e44a8c34e70e02251bfb578a6e26d6de6eedbed106cd78211d2fd64d28b6281d54924696554e4e966559644243753ac5df73c87f283b0927533d3315696215
-  languageName: node
-  linkType: hard
-
-"onetime@npm:^5.1.2":
-  version: 5.1.2
-  resolution: "onetime@npm:5.1.2"
-  dependencies:
-    mimic-fn: "npm:^2.1.0"
-  checksum: 10c0/ffcef6fbb2692c3c40749f31ea2e22677a876daea92959b8a80b521d95cca7a668c884d8b2045d1d8ee7d56796aa405c405462af112a1477594cc63531baeb8f
   languageName: node
   linkType: hard
 
@@ -8804,7 +8715,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-key@npm:^3.0.0, path-key@npm:^3.1.0":
+"path-key@npm:^3.1.0":
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
   checksum: 10c0/748c43efd5a569c039d7a00a03b58eecd1d75f3999f5a28303d75f521288df4823bc057d8784eb72358b2895a05f29a070bc9f1f17d28226cc4e62494cc58c4c
@@ -10110,7 +10021,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3":
+"signal-exit@npm:^3.0.2":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: 10c0/25d272fa73e146048565e08f3309d5b942c1979a6f4a58a8c59d5fa299728e9c2fcd1a759ec870863b1fd38653670240cd420dad2ad9330c71f36608a6a1c912
@@ -10611,13 +10522,6 @@ __metadata:
   version: 3.0.0
   resolution: "strip-bom@npm:3.0.0"
   checksum: 10c0/51201f50e021ef16672593d7434ca239441b7b760e905d9f33df6e4f3954ff54ec0e0a06f100d028af0982d6f25c35cd5cda2ce34eaebccd0250b8befb90d8f1
-  languageName: node
-  linkType: hard
-
-"strip-final-newline@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "strip-final-newline@npm:2.0.0"
-  checksum: 10c0/bddf8ccd47acd85c0e09ad7375409d81653f645fda13227a9d459642277c253d877b68f2e5e4d819fe75733b0e626bac7e954c04f3236f6d196f79c94fa4a96f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- mocha was the last task still piped through gulp. Add **mocha** as a direct devDependency (it was transitive via `gulp-mocha`) and run the `test` script as `mocha --require @babel/register test/test.js` — the same invocation the gulp task wrapped. Drop `gulp-mocha` and remove the gulp mocha task/import.
- Update `knip.json`: knip now traces `@babel/register` through the test script and auto-detects `test/test.js` as the mocha spec, so the `ignoreDependencies` entry and the explicit `entry` pattern are redundant.
- Update the CLAUDE.md `yarn test` note.
- mocha stays at its current major (10) — this is a runner change, not a version bump (the bump to 11 is an easy follow-up).

The gulpfile now contains **only build/dev/release tasks**; all linting and testing run as direct CLIs.

## Test plan
- [x] `yarn test` — 109 passing via direct mocha
- [x] `yarn lint` — full chain green (js, css, html, knip, format)
- [x] `yarn build` — gulpfile still loads after removing the task/import

🤖 Generated with [Claude Code](https://claude.com/claude-code)