### PR TITLE
Force serialize-javascript to 7.0.5 to clear advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
     "webpack": "^5.107.2",
     "webpack-stream": "^7.0.0"
   },
+  "resolutions": {
+    "serialize-javascript": "^7.0.5"
+  },
   "babel": {
     "presets": [
       "@babel/preset-env"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9118,15 +9118,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"randombytes@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "randombytes@npm:2.1.0"
-  dependencies:
-    safe-buffer: "npm:^5.1.0"
-  checksum: 10c0/50395efda7a8c94f5dffab564f9ff89736064d32addf0cc7e8bf5e4166f09f8ded7a0849ca6c2d2a59478f7d90f78f20d8048bca3cdf8be09d8e8a10790388f3
-  languageName: node
-  linkType: hard
-
 "range-parser@npm:~1.2.1":
   version: 1.2.1
   resolution: "range-parser@npm:1.2.1"
@@ -9826,12 +9817,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "serialize-javascript@npm:6.0.2"
-  dependencies:
-    randombytes: "npm:^2.1.0"
-  checksum: 10c0/2dd09ef4b65a1289ba24a788b1423a035581bef60817bea1f01eda8e3bda623f86357665fe7ac1b50f6d4f583f97db9615b3f07b2a2e8cbcb75033965f771dd2
+"serialize-javascript@npm:^7.0.5":
+  version: 7.0.5
+  resolution: "serialize-javascript@npm:7.0.5"
+  checksum: 10c0/7b7818e5267f6d474ec7a56d36ba69dd712726a13eab37706ec94615fb7ca8945471f2b7fb0dc9dbe8c79c1930c1079d97f66f91315c8c8c2ca6c38898cec96f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- mocha pins `serialize-javascript` at `^6.0.2` (unchanged even in mocha 11), leaving 6.0.2 in the tree, flagged by **GHSA-5c6j-r48x-rmvq** (RCE, high, `<=7.0.2`) and **GHSA-qj8w-gfj5-8c6v** (DoS, moderate, `<7.0.5`).
- mocha is the only consumer, so add a `yarn resolutions` override forcing `serialize-javascript` to `^7.0.5`, which patches both. mocha tolerates the major bump — the test suite passes on 7.0.5.
- Dropped the raw `yarn npm audit` from 11→10 high and 26→25 moderate.

All affected packages are devDependencies (the app ships zero runtime deps), so this is dev-toolchain hardening, not a user-facing fix.

## Test plan
- [x] `yarn test` — 109 passing (mocha on serialize-javascript 7.0.5)
- [x] `yarn lint` — full chain green
- [x] `yarn build` — passes
- [x] `yarn npm audit` no longer flags serialize-javascript

🤖 Generated with [Claude Code](https://claude.com/claude-code)