### PR TITLE
Catch typeof of undeclared variables

### DIFF
--- a/dwst/scripts/controller/connection.js
+++ b/dwst/scripts/controller/connection.js
@@ -52,7 +52,7 @@ export default class ConnectionHandler {
     const socket = this._dwst.model.connection.getSocket();
     if (socket === null || socket.isClosing() || socket.isClosed()) {
       let msg;
-      if (typeof foo === 'string') {
+      if (typeof buffer === 'string') {
         msg = buffer;
       } else {
         msg = `<${buffer.byteLength}B of data> `;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -83,6 +83,7 @@ export default [
       'no-extend-native': 'error',
       'no-useless-call': 'error',
       'no-useless-escape': 'error',
+      'no-undef': ['error', { typeof: true }],
       'no-undef-init': 'error',
       'no-undefined': 'error',
       'no-continue': 'error',


### PR DESCRIPTION
## Summary

Enable `no-undef`'s `typeof` option (`['error', { typeof: true }]`) so undeclared identifiers used inside `typeof` checks are flagged.

ESLint's `no-undef` intentionally ignores `typeof` operands so feature-detection idioms like `typeof WeakMap !== 'undefined'` don't error. That carve-out also silently swallowed a real typo in `ConnectionHandler.send`:

```js
if (typeof foo === 'string') {   // `foo` is undeclared — should be `buffer`
  msg = buffer;
} else {
  msg = `<${buffer.byteLength}B of data> `;
}
```

Because `typeof <undeclared>` is always `'undefined'`, the first branch was dead code: every send to a closed socket fell through to the `else`. For **text** sends `buffer.byteLength` is `undefined`, so the `NoConnection` message read `Cannot send: <undefinedB of data>` instead of echoing the text. (Binary sends were unaffected — `byteLength` is a real number there.) Reproduced in production.

## Changes

- `eslint.config.mjs` — turn on `no-undef`'s `typeof` option.
- `dwst/scripts/controller/connection.js` — fix `typeof foo` → `typeof buffer`, required for the stricter rule to pass.

Verified that every other `typeof <identifier>` in the shipped source operates on a declared local or a known global (`VERSION`), so the rule flags only genuine mistakes. `yarn lint` and `yarn test` (109 passing) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)