### PR TITLE
Use dvh to fix log area hidden behind mobile URL bar

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -37,7 +37,7 @@
 
     "function-url-scheme-allowed-list": [],
     "selector-attribute-operator-allowed-list": ["="],
-    "unit-allowed-list": ["%", "ch", "em", "pt", "px", "vh", "vw"],
+    "unit-allowed-list": ["%", "ch", "em", "pt", "px", "dvh", "vw"],
     "at-rule-allowed-list": ["media", "import"],
     "media-feature-name-allowed-list": ["min-width"],
     "selector-pseudo-class-allowed-list": [

--- a/dwst/styles/_log.css
+++ b/dwst/styles/_log.css
@@ -31,7 +31,7 @@ Styleguide 2.12
 
 .dwst-log__clear {
   float: left;
-  height: calc(100vh - var(--dwst-bar-height));
+  height: calc(100dvh - var(--dwst-bar-height));
 }
 .dwst-log__item--command {
   margin-top: 1ch;


### PR DESCRIPTION
## Summary

Fixes #193 — part of the UI going behind the URL bar on mobile.

`.dwst-log__clear` sized the log area with `calc(100vh - var(--dwst-bar-height))`. On mobile, `100vh` resolves to the **largest** viewport (URL bar retracted), so while the URL bar is showing the log is taller than the visible area and its top is pushed up behind the bar — the screenshot in #193.

Dynamic viewport units (`dvh`) track the *visible* viewport as browser chrome shows and hides, which is exactly this case. They didn't exist when #193 was filed in 2017 (the only options then were unreliable JS `resize` listeners or the iOS-only `-webkit-fill-available` hack), which is largely why the issue lingered. `dvh` has been Baseline since 2022 and is supported by every browser in this project's browserslist targets (`last 1 versions` → Chrome/Edge/Firefox/Safari), so no `vh` fallback is needed.

## Changes

- `dwst/styles/_log.css` — `100vh` → `100dvh`.
- `.stylelintrc` — replace `vh` with `dvh` in `unit-allowed-list`. `vh` now has no remaining users; disallowing it also guards against reintroducing this exact bug. `vw` stays (still used for responsive `font-size`, and viewport width isn't affected by browser chrome, so `dvw` would be a no-op).

`yarn lint` is green (including `no-unsupported-browser-features`, which confirms the targets support `dvh`).

## Verification note

This cannot be reproduced in Chrome DevTools device mode — the emulator renders a fixed viewport and never simulates the dynamic URL bar, so `100vh` and `100dvh` look identical there. The fix is spec-correct by the definition of `dvh`; confirming it visually requires a real device (Android via `chrome://inspect`, or iOS via Safari Web Inspector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)