### PR TITLE
Add CD workflow to deploy to dwst.github.io

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,59 @@
+name: CD
+on:
+  push:
+    branches:
+      - main
+# Serialize deploys so two pushes can't race on the dwst.github.io working tree.
+concurrency:
+  group: cd
+  cancel-in-progress: false
+permissions:
+  contents: read
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # git describe --tags drives VERSION; tags are needed for it to work.
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+      - name: Configure deploy key
+        env:
+          DEPLOY_KEY: ${{ secrets.PAGES_DEPLOY_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t rsa,ed25519 github.com >> ~/.ssh/known_hosts
+      - name: Clone the production site
+        run: git clone git@github.com:dwst/dwst.github.io.git release
+      - name: Build and overlay the new version
+        run: |
+          yarn gulp buildWithoutLinks
+          yarn gulp addNewStuff
+          yarn gulp updateReleaseSymlinks
+      - name: Dereference root symlinks into real files
+        # GitHub Pages (legacy) does not serve symlinked files, so the live
+        # index.html / service_worker.js must be real files pointing at the
+        # latest stable version, not symlinks.
+        run: |
+          cd release
+          for f in index.html service_worker.js; do
+            if [ -L "$f" ]; then
+              cp --remove-destination "$(readlink -f "$f")" "$f"
+            fi
+          done
+      - name: Deploy to dwst.github.io
+        run: |
+          VERSION="$(git describe --tags)"
+          cd release
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to deploy."
+            exit 0
+          fi
+          git -c user.name="github-actions[bot]" \
+              -c user.email="github-actions[bot]@users.noreply.github.com" \
+              commit -m "Deploy $VERSION"
+          git push origin HEAD:master


### PR DESCRIPTION
## Summary

Restores automated production deployment, which has been broken since the Travis CI shutdown — the production site (`dwst/dwst.github.io`) has not received a real deploy since 2021-06-23.

A new **CD** workflow runs on every push to `main` and reproduces the old Travis two-tier model:
- **Tagged commits** (`git describe` → e.g. `2.6.5`) publish a clean version directory and become the new site root.
- **Untagged commits** (e.g. `2.6.4-81-g…`) publish as pre-release directories without disturbing the root.

## How it works

1. Checks out with `fetch-depth: 0` (tags drive `VERSION`).
2. Reuses the existing `setup` composite action.
3. Loads an SSH deploy key from the `PAGES_DEPLOY_KEY` secret.
4. Clones `dwst/dwst.github.io` (with history).
5. Runs the existing exported gulp tasks `buildWithoutLinks` → `addNewStuff` → `updateReleaseSymlinks`.
6. Dereferences the root `index.html` / `service_worker.js` symlinks into real files — GitHub Pages (legacy) does not serve symlinked files, which matches what is currently live in production.
7. Commits `Deploy <VERSION>` and pushes to `dwst.github.io:master`.

## Design notes

- **No `gulpfile.babel.js` changes** — only already-exported tasks are invoked, so the build pipeline is untouched.
- **No third-party Actions** — the deploy key is configured with plain `ssh-keyscan` + file writes, consistent with the project's minimal-dependency philosophy (only `actions/checkout` and the repo's own composite action, as in `ci.yml`).
- `concurrency: cd` serializes deploys so two merges cannot race on the github.io working tree.

## Required before merge

The cross-repo push needs a credential (the missing piece that broke deploys — `GITHUB_TOKEN` cannot write to a different repo):

1. Generate an SSH keypair.
2. Add the **public** key as a write-enabled deploy key on `dwst/dwst.github.io`.
3. Add the **private** key as the `PAGES_DEPLOY_KEY` secret on `dwst/dwst`.

The secret and deploy key must exist before this merges, or the first CD run will fail on push.

## Verification

The overlay + dereference mechanic was dry-run against a real clone of `dwst.github.io`: the new pre-release directory is added correctly, the root symlinks track the latest stable (`2.6.4`), and the dereferenced root files are byte-identical to what is currently live (`index.html` 3750 B, `service_worker.js` 1744 B, `<base href="/2.6.4/">`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)