### PR TITLE
Fix binary asset corruption in gulp 5 build

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -224,7 +224,7 @@ export function buildHtml() {
 
 export function buildImages() {
   return gulp
-    .src(sourcePaths.images)
+    .src(sourcePaths.images, { encoding: false })
     .pipe(gulp.dest(targetDirs.images))
     .pipe(
       rename((p) => {
@@ -236,7 +236,7 @@ export function buildImages() {
 
 export function buildSprites() {
   return gulp
-    .src(sourcePaths.sprites)
+    .src(sourcePaths.sprites, { encoding: false })
     .pipe(gulp.dest(targetDirs.sprites))
     .pipe(
       rename((p) => {


### PR DESCRIPTION
## Summary

All PNG/ICO assets produced by the build are corrupted. This surfaced as soon as the new CD workflow started shipping builds — e.g. `https://dwst.github.io/2.6.4-82-g6d2dbe6/sprites/minilogo-hover.png` is not a valid PNG.

## Root cause

`gulp.src()` in gulp 5 (vinyl-fs 4) reads files as **UTF-8 text by default**. For binary assets this is lossy: any byte > 0x7F that isn't valid UTF-8 is decoded to U+FFFD and re-encoded as `EF BF BD`. A PNG's leading `0x89` becomes `EF BF BD`, and the file roughly doubles in size.

Observed on the deployed sprite:

| | bytes | first bytes | `file` |
|---|---|---|---|
| source | 2582 | `89 50 4E 47` (`‰PNG`) | PNG image data |
| deployed | 4468 | `EF BF BD 50 4E 47` | data |

`buildImages` and `buildSprites` both copy binaries through `gulp.src(...).pipe(gulp.dest(...))` without disabling encoding, so every favicon/icon/sprite was affected. The bug was latent because the gulp 4 → 5 bump landed while nothing was being deployed; the old gulp 4 build read binaries correctly.

## Fix

Pass `{ encoding: false }` to `gulp.src()` in both binary-asset tasks so files are read as raw buffers.

## Verification

After the fix, `yarn build` output matches the sources byte-for-byte (identical md5) for all 6 sprites and all 6 images, and `file` reports valid `PNG image data` again. `yarn lint:js` passes.

Once merged, the next deploy will overwrite the corrupted assets in the published version directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)