### PR TITLE
Fix binary corruption in addNewStuff release copy

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -314,7 +314,9 @@ export function ungitCurrent() {
 export const getOldStuff = gulp.series(deleteRelease, getCurrent, ungitCurrent);
 
 export function addNewStuff() {
-  return gulp.src(path.join(buildBase, '**/*')).pipe(gulp.dest(releaseBase));
+  return gulp
+    .src(path.join(buildBase, '**/*'), { encoding: false })
+    .pipe(gulp.dest(releaseBase));
 }
 
 export function deleteRelease() {


### PR DESCRIPTION
## Summary

Follow-up to #497. That PR fixed binary reads in `buildImages` / `buildSprites`, but the deployed sprites/icons were **still corrupt** — verified against the live deploy (`https://dwst.github.io/2.6.4-84-gcc1f8cf/sprites/minilogo-hover.png` was still `data`, not a PNG).

## Root cause

The release pipeline is `buildWithoutLinks` → `addNewStuff` → `updateReleaseSymlinks`. `addNewStuff` copies the entire build tree into `release/` through *another* encoding-less `gulp.src()`:

```js
return gulp.src(path.join(buildBase, '**/*')).pipe(gulp.dest(releaseBase));
```

So #497 produced correct PNGs in `build/`, but `addNewStuff` re-read them as UTF-8 and re-corrupted them on the way into `release/` (the tree that actually gets committed to `dwst.github.io`). Same gulp 5 vinyl-fs default as #497, just a third call site that the earlier fix didn't cover.

## Fix

Add `{ encoding: false }` to `addNewStuff` as well.

## Verification

Reproduced the exact CD sequence locally (`yarn gulp buildWithoutLinks` then `yarn gulp addNewStuff`) and confirmed the files in `release/` — the ones the workflow commits — match their sources byte-for-byte (sprite, icon, and favicon.ico) and `file` reports valid `PNG image data`. Full `yarn lint` passes.

Once merged, the next CD deploy will publish a version directory with intact binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)