### PR TITLE
Trigger CD on version tags

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - main
+    tags:
+      # Tagging a release deploys it as a clean version dir and new site
+      # root; untagged pushes to main publish as pre-release directories.
+      - 'v*'
+  workflow_dispatch:
 # Serialize deploys so two pushes can't race on the dwst.github.io working tree.
 concurrency:
   group: cd


### PR DESCRIPTION
## Summary

CD (#496) only triggered on `push` to the `main` **branch**. Pushing a tag is a separate ref event that didn't match, so tagging a release deployed nothing — `v2.6.5` was pushed but no `2.6.5/` directory or site-root update was produced.

## Fix

Add a `tags: ['v*']` trigger (matching the `v`-prefixed `VERSION` format the build requires) so tagging a release runs CD: `git describe` resolves to the exact tag, producing a clean version directory that becomes the new site root. Untagged pushes to `main` continue to publish pre-release directories. Also adds `workflow_dispatch` for manual re-runs.

## Note on recovering v2.6.5

GitHub Actions runs the workflow file **as it exists at the pushed ref**. The current `v2.6.5` tag points at `6fd8e43`, which predates this change, so re-pushing it as-is still wouldn't trigger CD. After this merges, `v2.6.5` needs to be moved to a commit that contains the trigger (i.e. re-tagged on the updated `main`) for it to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)