### PR TITLE
Replace deprecated substr with startsWith and slice

### DIFF
--- a/dwst/scripts/lib/utils.js
+++ b/dwst/scripts/lib/utils.js
@@ -13,8 +13,8 @@
 
 export default {
   parseNum: (str) => {
-    if (str.length > 2 && str.substr(0, 2) === '0x') {
-      return parseInt(str.substr(2), 16);
+    if (str.length > 2 && str.startsWith('0x')) {
+      return parseInt(str.slice(2), 16);
     }
     const num = parseInt(str, 10);
     return num;


### PR DESCRIPTION
## Summary
- `str.substr()` is deprecated; replaced with `str.startsWith()` and `str.slice()`
- Both do the same thing, `startsWith` is the more readable form for the prefix check

## Test plan
- [ ] `yarn test` passes
- [ ] `yarn lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)