### PR TITLE
Replace new Date().getTime() with Date.now()

### DIFF
--- a/dwst/scripts/functions/time.js
+++ b/dwst/scripts/functions/time.js
@@ -36,6 +36,6 @@ export default class Time extends DwstFunction {
   }
 
   run() {
-    return String(Math.round(new Date().getTime() / 1000));
+    return String(Math.round(Date.now() / 1000));
   }
 }

--- a/dwst/scripts/model/socket.js
+++ b/dwst/scripts/model/socket.js
@@ -22,14 +22,14 @@ export default class Socket {
   }
 
   resetClock() {
-    this._sessionStartTime = new Date().getTime();
+    this._sessionStartTime = Date.now();
   }
 
   get sessionLength() {
     if (this._sessionStartTime === null) {
       return null;
     }
-    const currentTime = new Date().getTime();
+    const currentTime = Date.now();
     return currentTime - this._sessionStartTime;
   }
 


### PR DESCRIPTION
## Summary
- `Date.now()` is the modern, concise form of `new Date().getTime()`
- Updated in `model/socket.js` (session timing) and `functions/time.js` (timestamp generation)

## Test plan
- [ ] `yarn test` passes
- [ ] `yarn lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)