### PR TITLE
Replace indexOf check with includes in service worker

### DIFF
--- a/dwst/scripts/service_worker.js
+++ b/dwst/scripts/service_worker.js
@@ -32,7 +32,7 @@ addEventListener('install', (evt) => {
 /* eslint-disable consistent-return */
 
 addEventListener('fetch', (evt) => {
-  if (evt.request.url.indexOf('google-analytics.com') !== -1) {
+  if (evt.request.url.includes('google-analytics.com')) {
     return false;
   }
   evt.respondWith(


### PR DESCRIPTION
## Summary
- `str.includes()` is the modern replacement for `str.indexOf() !== -1`

## Test plan
- [ ] `yarn test` passes
- [ ] `yarn lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)