### PR TITLE
Replace manual hex zero-padding with padStart

### DIFF
--- a/dwst/scripts/ui/components/terminal.js
+++ b/dwst/scripts/ui/components/terminal.js
@@ -91,7 +91,7 @@ function partToMlog(part) {
     }
     const charCode = part.chr.charCodeAt(0);
     if (charCode < 0x80) {
-      const charHex = `0${charCode.toString(16)}`.slice(-2);
+      const charHex = charCode.toString(16).padStart(2, '0');
       return `\\x${charHex}`;
     }
     return `\\u{${charCode.toString(16)}}`;

--- a/dwst/scripts/ui/renderers/mlog.js
+++ b/dwst/scripts/ui/renderers/mlog.js
@@ -15,11 +15,7 @@ import m from '../../types/m/m.js';
 import utils from '../../lib/utils.js';
 
 function hexify(num) {
-  const hex = num.toString(16);
-  if (hex.length < 2) {
-    return `0${hex}`;
-  }
-  return hex;
+  return num.toString(16).padStart(2, '0');
 }
 
 function charify(num) {


### PR DESCRIPTION
## Summary
- Both `mlog.js` (`hexify`) and `terminal.js` hand-rolled two-character hex padding; replaced with `padStart(2, '0')`
- Behaviour is identical: single hex digit gets a leading zero, two-digit values pass through unchanged

## Test plan
- [ ] `yarn test` passes
- [ ] `yarn lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)