### PR TITLE
Use crypto.getRandomValues instead of Math.random for random bytes

### DIFF
--- a/dwst/scripts/functions/random_bytes.js
+++ b/dwst/scripts/functions/random_bytes.js
@@ -36,18 +36,12 @@ export default class RandomBytes extends DwstFunction {
   }
 
   run(args) {
-    const randombyte = () => {
-      const out = Math.floor(Math.random() * (0xff + 1));
-      return out;
-    };
     let num = 16;
     if (args.length === 1) {
       num = args[0].value;
     }
-    const bytes = [];
-    for (let i = 0; i < num; i++) {
-      bytes.push(randombyte());
-    }
-    return new Uint8Array(bytes);
+    const bytes = new Uint8Array(num);
+    crypto.getRandomValues(bytes);
+    return bytes;
   }
 }


### PR DESCRIPTION
## Summary
- `Math.random()` is not cryptographically secure; `crypto.getRandomValues()` is the correct API for generating random bytes
- Also simplifies the implementation: allocate a `Uint8Array` of the right size, fill it in one call, return it directly

## Test plan
- [ ] `yarn test` passes
- [ ] `yarn lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)