### PR TITLE
Replace FileReader with blob.arrayBuffer()

### DIFF
--- a/dwst/scripts/controller/socket.js
+++ b/dwst/scripts/controller/socket.js
@@ -86,12 +86,9 @@ export default class SocketHandler {
     if (typeof msg === 'string') {
       this._dwst.ui.terminal.tlog(msg, 'received');
     } else {
-      const fr = new FileReader();
-      fr.addEventListener('load', (evt) => {
-        const buffer = evt.target.result;
+      msg.arrayBuffer().then((buffer) => {
         this._dwst.ui.terminal.blog(buffer, 'received');
       });
-      fr.readAsArrayBuffer(msg);
     }
   }
 

--- a/dwst/scripts/functions/file.js
+++ b/dwst/scripts/functions/file.js
@@ -38,12 +38,7 @@ export default class File extends DwstFunction {
   _readFile() {
     return new Promise((resolve) => {
       this._dwst.ui.fileInput.read((file) => {
-        const reader = new FileReader();
-        reader.addEventListener('load', (evt) => {
-          const buffer = evt.target.result;
-          resolve(buffer);
-        });
-        reader.readAsArrayBuffer(file);
+        file.arrayBuffer().then(resolve);
       });
     });
   }


### PR DESCRIPTION
## Summary
- `Blob.prototype.arrayBuffer()` (available since Chrome 76 / Firefox 69 / Safari 14.1) replaces the callback-based `FileReader` API with a direct Promise
- Applied in `controller/socket.js` (incoming binary WebSocket messages) and `functions/file.js` (user file picker)

## Test plan
- [ ] `yarn test` passes
- [ ] `yarn lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)